### PR TITLE
Issue 198 resolution  - Background resizing issue

### DIFF
--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -14,7 +14,7 @@
   }
 }
 @mixin desktop{
-  @media(max-width:991px){
+  @media(max-width:1199px){
     @content;
   }
 }

--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -14,7 +14,7 @@
   }
 }
 @mixin desktop{
-  @media(max-width:1199px){
+  @media(max-width:1200px){
     @content;
   }
 }


### PR DESCRIPTION
Solved the Issue https://github.com/CircuitVerse/Blog/issues/198

As the dimensions of the window exceed 991, the above image shows a sudden change and sticks to the top.

Now it looks like this:

![Screenshot 2024-01-07 185917](https://github.com/CircuitVerse/Blog/assets/119029228/79691fff-252d-473f-9941-3201be7798ab)
