### PR TITLE
fix: Changed the footer year

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,7 +64,7 @@ google_analitycs_id = "UA-112678513-4" # your id
 # contact form action
 contact_form_action = "https://formspree.io/support@circuitverse.org" # contact form works with : https://formspree.io
 # copyright
-copyright = "&copy; 2023 [CircuitVerse](https://circuitverse.org) All Rights Reserved"
+copyright = "&copy; 2024 [CircuitVerse](https://circuitverse.org) All Rights Reserved"
 
 # preloader
 [params.preloader]

--- a/content/posts/my_new_post.md
+++ b/content/posts/my_new_post.md
@@ -1,0 +1,6 @@
+---
+title: "My_new_post"
+date: 2024-01-24T00:57:36+05:30
+draft: true
+---
+


### PR DESCRIPTION
Fixes #205 

Changed footer copyright year from `2023` to `2024` 