### PR TITLE
Added a button to navigate back to the main CV website(Solves #229)

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,85 @@
+<header class="fixed-top navigation">
+    <div class="container">
+      <!-- navbar -->
+      <nav class="navbar px-0 navbar-expand-lg navbar-light bg-transparent">
+        <a class="navbar-brand" href="{{ .Site.BaseURL }}">
+          <img
+            class="img-fluid"
+            src="{{ .Site.Params.logo | relURL }}"
+            alt="{{ .Site.Title }}"
+          />
+        </a>
+        <button
+          class="navbar-toggler border-0 px-0"
+          type="button"
+          data-toggle="collapse"
+          data-target="#navigation"
+        >
+          <i class="ti-menu text-dark h3"></i>
+        </button>
+  
+        <div class="collapse navbar-collapse text-center" id="navigation">
+          <ul class="navbar-nav ml-auto">
+            <li class="nav-item">
+              <a class="nav-link" href="{{ .Site.BaseURL }}"
+                >{{ with .Site.Params.Home }} {{ . }} {{ end }}</a
+              >
+            </li>
+            {{ range .Site.Menus.main }} {{ if .HasChildren }}
+            <li class="nav-item dropdown">
+              <a
+                class="nav-link dropdown-toggle"
+                href="#"
+                role="button"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+              >
+                {{ .Name }}
+              </a>
+              <div class="dropdown-menu">
+                {{ range .Children }}
+                <a class="dropdown-item" href="{{ .URL | absURL }}"
+                  >{{ .Name }}</a
+                >
+                {{ end }}
+              </div>
+            </li>
+            {{ else }}
+            <li class="nav-item">
+              <a class="nav-link" href="{{ .URL | absURL }}">{{ .Name }}</a>
+            </li>
+            {{ end }} {{ end }}
+
+            <!-- CircuitVerse Button -->
+            <li class="nav-item">
+              <a href="https://circuitverse.org" class="nav-link" target="_blank" rel="noopener">
+                Go to CircuitVerse
+              </a>
+            </li>
+          </ul>
+          {{ if .Site.Params.search.enable }} {{ "<!-- search -->" | safeHTML }}
+          <div class="search">
+            <button id="searchOpen" class="search-btn">
+              <i class="ti-search"></i>
+            </button>
+            <div class="search-wrapper">
+              <form action="{{ `search` | absURL }}" class="h-100">
+                <input
+                  class="search-box px-4"
+                  id="search-query"
+                  name="s"
+                  type="search"
+                  placeholder="Type & Hit Enter..."
+                />
+              </form>
+              <button id="searchClose" class="search-close">
+                <i class="ti-close text-dark"></i>
+              </button>
+            </div>
+          </div>
+          {{ end }}
+        </div>
+      </nav>
+    </div>
+  </header>


### PR DESCRIPTION
Solves the following Issue:-
Add Navigation Button from Blog to Main Site #229

These changes will:
Override the default header template to add a "Go to Circuitverse" button next to the existing "Contact" button
Style the button to match the existing UI/UX of the blog site
Link the button to the main CircuitVerse site (https://circuitverse.org)
The button will be visible on all pages of the blog and will provide an easy way for users to navigate back to the main site. The styling matches the existing theme while maintaining consistency with CircuitVerse's design language.



Before(No button to go back to main website (https://circuitverse.org) )

<img width="1440" alt="Screenshot 2025-02-08 at 3 15 55 AM" src="https://github.com/user-attachments/assets/055f2a46-ec0f-437a-bc2b-d3651ed86007" />


After:


https://github.com/user-attachments/assets/bc8a6c12-5e26-4326-b5eb-00c594b7e806

