### PR TITLE
Fix: Update form control focus border and add green box-shadow

### DIFF
--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -176,3 +176,8 @@ body .toc a:hover {
   background: #368f6e !important;
   border-color: #368f6e !important;
 }
+
+.form-control:focus {
+  border-color: #40ba84 !important;
+  box-shadow: 0 0 0 0.2rem rgba(64, 186, 132, 0.25) !important;
+}

--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -1,52 +1,60 @@
-@mixin mobile-xs{
-  @media(max-width:400px){
-    @content;
-  }
-}
-@mixin mobile{
-  @media(max-width:575px){
-    @content;
-  }
-}
-@mixin tablet{
-  @media(max-width:767px){
-    @content;
-  }
-}
-@mixin desktop{
-  @media(max-width:991px){
-    @content;
-  }
-}
-@mixin desktop-lg{
-  @media(max-width:1200px){
-    @content;
-  }
-}
-@mixin desktop-xl{
-  @media(min-width:1201px){ // Overriden here
+@mixin mobile-xs {
+  @media(max-width:400px) {
     @content;
   }
 }
 
-@mixin size($size){
-  width: $size; height: $size;
+@mixin mobile {
+  @media(max-width:575px) {
+    @content;
+  }
+}
+
+@mixin tablet {
+  @media(max-width:767px) {
+    @content;
+  }
+}
+
+@mixin desktop {
+  @media(max-width:991px) {
+    @content;
+  }
+}
+
+@mixin desktop-lg {
+  @media(max-width:1200px) {
+    @content;
+  }
+}
+
+@mixin desktop-xl {
+  @media(min-width:1201px) {
+    // Overriden here
+    @content;
+  }
+}
+
+@mixin size($size) {
+  width: $size;
+  height: $size;
 }
 
 /*
   Custom Overrides
 */
 .navbar-brand {
-  @media(max-width:767px){
+  @media(max-width:767px) {
     .img-fluid {
       max-width: 200px;
       margin-top: 10px;
     }
   }
 }
+
 // Circuitverse Logo
-.navigation{
-  .img-fluid{
+.navigation {
+  .img-fluid {
     max-width: 70% !important;
   }
 }
@@ -57,21 +65,26 @@
   padding: 10px 20px !important;
   font-size: 1rem;
 }
+
 .navbar-light .navbar-nav .nav-link:hover {
   color: #40ba84 !important;
   border-radius: 5px;
 }
-.search-btn{
+
+.search-btn {
   font-weight: bold;
   margin-left: 1rem;
 }
-.search-btn:hover{
+
+.search-btn:hover {
   color: #40ba84;
 }
-.navbar-brand{
+
+.navbar-brand {
   padding-bottom: 0;
 }
-.navbar-expand-lg .navbar-nav .nav-item:nth-child(1){
+
+.navbar-expand-lg .navbar-nav .nav-item:nth-child(1) {
   display: none;
 }
 
@@ -79,44 +92,53 @@
 .block a {
   color: #40ba84;
 }
+
 .block a:hover {
   color: #40ba84;
 }
-.block .btn-transparent{
+
+.block .btn-transparent {
   border-bottom: 1px solid #40ba84;
 }
 
 // Pagination theme
 .mt-5 .pagination .page-item.active .page-link {
-  background: #40ba84 ;
+  background: #40ba84;
 }
+
 .mt-5 .pagination .page-item .page-link:hover {
-  background: #40ba84 ;
+  background: #40ba84;
 }
 
 // Button Theme
 .container .btn-primary {
-  background: #40ba84 ;
-  border-color: #40ba84 ;
+  background: #40ba84;
+  border-color: #40ba84;
 }
-.container .btn-primary:active,.container .btn-primary:hover, .container .btn-primary.focus, .container .btn-primary.active {
-  background: #40ba84 ;
-  border-color: #40ba84 ;
+
+.container .btn-primary:active,
+.container .btn-primary:hover,
+.container .btn-primary.focus,
+.container .btn-primary.active {
+  background: #40ba84;
+  border-color: #40ba84;
 }
 
 // Footer navlinks Theme
-.container .social-icon a{
-  color: #40ba84 ;
-  border-color: #40ba84 ;
+.container .social-icon a {
+  color: #40ba84;
+  border-color: #40ba84;
 }
+
 .container .social-icon a:hover {
-  background: #40ba84 ;
-  color: #fff ;
+  background: #40ba84;
+  color: #fff;
 }
+
 .text-center {
-  span{
-    a{
-      color: #40ba84 ;
+  span {
+    a {
+      color: #40ba84;
     }
   }
 }
@@ -137,30 +159,39 @@
 }
 
 body .toc a {
-    display: block;
-    text-decoration: none;
-    color: #000 !important; /* Dark black text color with !important */
-    font-weight: bold !important; /* Make the text bold with !important */
-    cursor: pointer;
-    margin-left: 10px; /* Adjust the margin to control the indentation */
-    margin-bottom: 5px; /* Reduce space between headings */
+  display: block;
+  text-decoration: none;
+  color: #000 !important;
+  /* Dark black text color with !important */
+  font-weight: bold !important;
+  /* Make the text bold with !important */
+  cursor: pointer;
+  margin-left: 10px;
+  /* Adjust the margin to control the indentation */
+  margin-bottom: 5px;
+  /* Reduce space between headings */
 }
 
 body .toc a:hover {
-      color: #4CAF50 !important; /* Light green text color on hover with !important */
- }
+  color: #4CAF50 !important;
+  /* Light green text color on hover with !important */
+}
 
- /* --- 992–1200px squeeze zone fixes --- */
+/* --- 992–1200px squeeze zone fixes --- */
 @media (min-width: 992px) and (max-width: 1199.98px) {
   .banner .illustration {
-    max-width: 540px !important;   /* ensure image size sticks */
-    right: 15px !important;        /* prevent overlap */
+    max-width: 540px !important;
+    /* ensure image size sticks */
+    right: 15px !important;
+    /* prevent overlap */
   }
 }
+
 /* In the squeeze band, cap the image and give the text a nudge */
 @media (min-width: 992px) and (max-width: 1199.98px) {
-  .section.pt-0 .row.shadow.bg-white.p-5 > div:first-child img {
-    width: 180px !important;        /* 320–360 works well */
+  .section.pt-0 .row.shadow.bg-white.p-5>div:first-child img {
+    width: 180px !important;
+    /* 320–360 works well */
   }
 }
 
@@ -177,7 +208,8 @@ body .toc a:hover {
   border-color: #368f6e !important;
 }
 
-.form-control:focus {
-  border-color: #40ba84 !important;
-  box-shadow: 0 0 0 0.2rem rgba(64, 186, 132, 0.25) !important;
+input.form-control:focus,
+textarea.form-control:focus {
+  border-color: #40ba84;
+  box-shadow: 0 0 0 0.2rem rgba(64, 186, 132, 0.25);
 }


### PR DESCRIPTION
## Fix: Button Hover & Form Control Focus Colors (Closes #257)

### Summary

This PR fixes UI consistency issues to match the CircuitVerse color scheme: **Form control focus state** - Text input fields now show a green border and subtle green glow on focus instead of red

### Changes

**File: `assets/scss/_mixins.scss`**

- Added focus state override for `.form-control` to use `#40ba84` border with a matching green box-shadow
- No submodule files were modified; all changes are safe from future submodule updates

### How to Test

1. Navigate to the contact page
2. Click on any text input field
3. The border should turn green (`#40ba84`) with a subtle green glow
4. It should **not** turn red at any point

### Screen Recording
[Screencast from 2025-12-24 14-15-40.webm](https://github.com/user-attachments/assets/edab8959-64be-42e9-a4ab-07ea7f26f7b0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reformatted theme and responsive styles for spacing and consistency across navigation, blog, pagination, buttons, footer social, and centered links.
  * Refined Table-of-Contents link styling for clearer appearance and hover behavior.
  * Enhanced form control focus states with a stronger green border and subtle glow for improved visual feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->