### PR TITLE
Update: copyright year to 2026 

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,7 +64,7 @@ google_analitycs_id = "UA-112678513-4" # your id
 # contact form action
 contact_form_action = "https://formspree.io/support@circuitverse.org" # contact form works with : https://formspree.io
 # copyright
-copyright = "&copy; 2025 [CircuitVerse](https://circuitverse.org) All Rights Reserved"
+copyright = "&copy; 2026 [CircuitVerse](https://circuitverse.org) All Rights Reserved"
 
 # preloader
 [params.preloader]


### PR DESCRIPTION
Fixes #260

### Before
- Footer copyright year: 2025
- 
<img width="1898" height="339" alt="image" src="https://github.com/user-attachments/assets/e2a7423a-d2fc-43e3-82c8-9b9a3e817148" />


### After
- Footer copyright year updated to 2026
<img width="1536" height="1024" alt="png" src="https://github.com/user-attachments/assets/cba8c6f5-11ec-4da5-9c65-f8fc0072d0a4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated copyright year in site configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->