### PR TITLE
fix : search bar box with a green outline border

### DIFF
--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -68,6 +68,23 @@
 .search-btn:hover{
   color: #40ba84;
 }
+
+// Search box visibility improvements
+.search-wrapper {
+  background: rgba(0, 0, 0, 0.05); // subtle overlay
+}
+.search-box {
+  border: 2px solid #40ba84 !important; // CircuitVerse green border
+  border-radius: 5px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15); // subtle shadow
+}
+.search-close {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 50%;
+  padding: 5px;
+  width: 35px;
+  height: 35px;
+}
 .navbar-brand{
   padding-bottom: 0;
 }

--- a/config.toml
+++ b/config.toml
@@ -64,7 +64,7 @@ google_analitycs_id = "UA-112678513-4" # your id
 # contact form action
 contact_form_action = "https://formspree.io/support@circuitverse.org" # contact form works with : https://formspree.io
 # copyright
-copyright = "&copy; 2025 [CircuitVerse](https://circuitverse.org) All Rights Reserved"
+copyright = "&copy; 2026 [CircuitVerse](https://circuitverse.org) All Rights Reserved"
 
 # preloader
 [params.preloader]

--- a/config.toml
+++ b/config.toml
@@ -7,8 +7,13 @@ theme = "northendlab-hugo"
 paperSize = "5"
 # post excerpt
 summaryLength = "10"
-# disqus short name
+# disqus short name (deprecated but kept for Hugo 0.73.0 compatibility)
 disqusShortname = "blog-circuitverse-org" # get your shortname form here : https://disqus.com
+
+# Disqus configuration (current Hugo format)
+[services]
+  [services.disqus]
+    shortname = "blog-circuitverse-org"
 
 [outputs]
 home = ["HTML", "AMP", "RSS", "JSON"]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,45 @@
+{{ define "main" }}
+
+<section class="section">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-8 mx-auto block shadow mb-5">
+        <h2>{{ .Title | markdownify }}</h2>
+        <div class="mb-3 post-meta">
+          <a href="{{ `author/` | relLangURL }}{{ .Params.Author | urlize | lower }}/">{{ .Params.Author | title }}</a>,
+          {{ .PublishDate.Format "Jan 2, 2006" }}, {{ range .Params.Categories }}
+          <a href="{{ `categories/` | relLangURL }}{{ . | urlize | lower }}/">{{ . | title }}</a>
+          {{ end }}
+        </div>
+        {{ if .Params.Image }}
+        <img src="{{ .Params.Image | relURL }}" class="img-fluid w-100 mb-4" alt="{{ .Title | markdownify }}">
+        {{ end }}
+        <div class="content mb-5">
+          {{ .Content }}
+        </div>
+        <div class="mb-3 post-meta">
+          {{range .Params.Tags }} <a href="{{ `tags/` | relLangURL}}{{ . | urlize | lower }}/">#{{ . | title }}</a>,  {{ end }}
+        </div>
+      </div>
+      <div class="col-lg-8 mx-auto block shadow">
+        {{ $related := .Site.RegularPages.Related . | first 5 }}
+        {{ with $related }}
+        <h3>See Also</h3>
+        <ul>
+          {{ range . }}
+          <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+          {{ end }}
+        </ul>
+        {{ end }}
+      </div>
+      {{ if .Site.Config.Services.Disqus.Shortname }}
+      <div class="col-lg-8 mx-auto block shadow">
+        <!-- comments -->
+        {{ template "_internal/disqus.html" . }}
+      </div>
+      {{ end }}
+    </div>
+  </div>
+</section>
+
+{{ end }}


### PR DESCRIPTION
commit : #261
the search bar now has a green outline border present to make it more visible .

before : 

<img width="1881" height="328" alt="Screenshot 2026-01-04 211135" src="https://github.com/user-attachments/assets/91b70bc3-7bb0-44a0-b4d3-80ef37bdf562" />

after : 
<img width="1919" height="1030" alt="Screenshot 2026-01-04 210234" src="https://github.com/user-attachments/assets/8e1d2857-9a0e-4d74-a0d3-71b9ad84077c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added blog post layout supporting title, author, date, featured image, content, tags, related-post suggestions, and optional comments.
  * Enabled Disqus comments via updated site configuration.

* **Style**
  * Added search interface styling (overlay, bordered search box, close button) and a navbar visibility tweak for large layouts.

* **Chores**
  * Updated copyright year to 2026.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->