### PR TITLE
fix: logo now redirects to main circuitverse.org domain (#6437)

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,78 @@
+<header class="fixed-top navigation">
+  <div class="container">
+    <!-- navbar -->
+    <nav class="navbar px-0 navbar-expand-lg navbar-light bg-transparent">
+      <a class="navbar-brand" href="https://circuitverse.org/">
+        <img
+          class="img-fluid"
+          src="{{ .Site.Params.logo | relURL }}"
+          alt="{{ .Site.Title }}"
+        />
+      </a>
+      <button
+        class="navbar-toggler border-0 px-0"
+        type="button"
+        data-toggle="collapse"
+        data-target="#navigation"
+      >
+        <i class="ti-menu text-dark h3"></i>
+      </button>
+
+      <div class="collapse navbar-collapse text-center" id="navigation">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-item">
+            <a class="nav-link" href="{{ .Site.BaseURL }}"
+              >{{ with .Site.Params.Home }} {{ . }} {{ end }}</a
+            >
+          </li>
+          {{ range .Site.Menus.main }} {{ if .HasChildren }}
+          <li class="nav-item dropdown">
+            <a
+              class="nav-link dropdown-toggle"
+              href="#"
+              role="button"
+              data-toggle="dropdown"
+              aria-haspopup="true"
+              aria-expanded="false"
+            >
+              {{ .Name }}
+            </a>
+            <div class="dropdown-menu">
+              {{ range .Children }}
+              <a class="dropdown-item" href="{{ .URL | absURL }}"
+                >{{ .Name }}</a
+              >
+              {{ end }}
+            </div>
+          </li>
+          {{ else }}
+          <li class="nav-item">
+            <a class="nav-link" href="{{ .URL | absURL }}">{{ .Name }}</a>
+          </li>
+          {{ end }} {{ end }}
+        </ul>
+        {{ if .Site.Params.search.enable }} {{ "<!-- search -->" | safeHTML }}
+        <div class="search">
+          <button id="searchOpen" class="search-btn">
+            <i class="ti-search"></i>
+          </button>
+          <div class="search-wrapper">
+            <form action="{{ `search` | absURL }}" class="h-100">
+              <input
+                class="search-box px-4"
+                id="search-query"
+                name="s"
+                type="search"
+                placeholder="Type & Hit Enter..."
+              />
+            </form>
+            <button id="searchClose" class="search-close">
+              <i class="ti-close text-dark"></i>
+            </button>
+          </div>
+        </div>
+        {{ end }}
+      </div>
+    </nav>
+  </div>
+</header>


### PR DESCRIPTION
The blog logo was previously linking to `.Site.BaseURL` (the blog home), which confused users who expected it to take them back to `circuitverse.org`.

This PR overrides the theme header to explicitly set the logo `href` to `https://circuitverse.org/`, fixing issue #6437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fixed-top responsive navigation bar with brand logo and menu system
  * Implemented dropdown menu support for navigation items with child elements
  * Integrated search functionality with toggle capability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->