### PR TITLE
Fix: contact form focus border color

### DIFF
--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -36,6 +36,7 @@
 /*
   Custom Overrides
 */
+$primary-color: #40ba84;
 .navbar-brand {
   @media(max-width:767px){
     .img-fluid {


### PR DESCRIPTION
## Summary

Fixes the contact form focus border color on the `/contact` page.

## Changes

- Updated the theme primary color override to `#40ba84`
- Ensured focused contact form fields use the correct green border
- Avoided adding `!important` for this fix

## Fixes

Closes #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved styling infrastructure for enhanced theme color consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->